### PR TITLE
62 deck aware card grid and deletion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,15 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "idb": "^8.0.3"
+      },
       "devDependencies": {
         "@eslint/js": "^9.26.0",
         "eslint": "^9.26.0",
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-jest": "^28.11.0",
+        "fake-indexeddb": "^6.0.1",
         "globals": "^16.1.0",
         "jest": "^29.7.0",
         "jsdoc": "^4.0.4",
@@ -2827,6 +2831,16 @@
         "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
+    "node_modules/fake-indexeddb": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.0.1.tgz",
+      "integrity": "sha512-He2AjQGHe46svIFq5+L2Nx/eHDTI1oKgoevBP+TthnjymXiKkeJQ3+ITeWey99Y5+2OaPFbI1qEsx/5RsGtWnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3264,6 +3278,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "dependencies": {
-        "idb": "^8.0.3"
-      },
       "devDependencies": {
         "@eslint/js": "^9.26.0",
         "eslint": "^9.26.0",
@@ -3278,12 +3275,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/idb": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
-      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
-      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,5 @@
   "jest": {
     "transform": {},
     "verbose": true
-  },
-  "dependencies": {
-    "idb": "^8.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "eslint": "^9.26.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-jest": "^28.11.0",
+    "fake-indexeddb": "^6.0.1",
     "globals": "^16.1.0",
     "jest": "^29.7.0",
     "jsdoc": "^4.0.4",
@@ -20,5 +21,8 @@
   "jest": {
     "transform": {},
     "verbose": true
+  },
+  "dependencies": {
+    "idb": "^8.0.3"
   }
 }

--- a/src/data/indexedDB.js
+++ b/src/data/indexedDB.js
@@ -4,7 +4,7 @@
    Choosing to use the idb library to simplify IndexedDB calls
 ------------------------------------------------------------------- */
 
-import { openDB } from 'idb';
+import { openDB } from 'https://cdn.jsdelivr.net/npm/idb@8/+esm';
 
 // DB CONSTANTS -----------------------------------------------------
 const DB_NAME = 'card-vault-db';

--- a/src/data/indexedDB.js
+++ b/src/data/indexedDB.js
@@ -45,12 +45,20 @@ export async function addCard(card) {
 }
 
 /**
- * Fetch all cards.
+ * Fetch all cards from specific deck by deckId
+ * @param {string} deckId
  * @returns {Promise<Object[]>} array of card objects
  */
-export async function getAllCards() {
+export async function getCardsFromDeck(deckId) {
+  const deck = await getDeckById(deckId);
+  if (!deck || !deck.cardIds) return [];
+
   const db = await dbPromise;
-  return db.getAll(CARD_STORE);
+  const tx = db.transaction(CARD_STORE, 'readonly');
+  const store = tx.objectStore(CARD_STORE);
+
+  const cards = await Promise.all(deck.cardIds.map((id) => store.get(id)));
+  return cards.filter(Boolean); // remove any undefined if id lookup fails
 }
 
 /**

--- a/src/data/indexedDB.js
+++ b/src/data/indexedDB.js
@@ -4,7 +4,7 @@
    Choosing to use the idb library to simplify IndexedDB calls
 ------------------------------------------------------------------- */
 
-import { openDB } from 'https://cdn.jsdelivr.net/npm/idb@8/+esm';
+import { openDB } from 'idb';
 
 // DB CONSTANTS -----------------------------------------------------
 const DB_NAME = 'card-vault-db';

--- a/src/pages/card-grid/card-grid.html
+++ b/src/pages/card-grid/card-grid.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Pokémon Card Grid</title>
+    <title>View All Cards</title>
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>

--- a/src/pages/card-grid/card-grid.js
+++ b/src/pages/card-grid/card-grid.js
@@ -1,27 +1,12 @@
-// import { getAllCards } from '../../data/indexedDB.js';
-// import { Card } from '../../data/card.js';
+import { getCardsFromDeck, getDeckById } from "../../data/indexedDB.js";
 
-// Dummy card data — replace with real getAllCards() later
-const dummyCards = [
-  {
-    id: '1',
-    name: 'Pikachu',
-    imageURL:
-      'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/25.png',
-  },
-  {
-    id: '2',
-    name: 'Charmander',
-    imageURL:
-      'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/4.png',
-  },
-  {
-    id: '3',
-    name: 'Bulbasaur',
-    imageURL:
-      'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png',
-  },
-];
+async function updateTitleWithDeckName(deckId) {
+  const deck = await getDeckById(deckId);
+  const heading = document.querySelector('h1');
+  if (deck && deck.name) {
+    heading.textContent = `${deck.name} Deck`;
+  }
+}
 
 // build and render the card grid
 function renderCardGrid(cards) {
@@ -97,19 +82,25 @@ function eventListenerSetup() {
 // entry point
 async function init() {
   const root = document.getElementById('card-grid-root');
-  const grid = renderCardGrid(dummyCards);
-  root.appendChild(grid);
 
-  //to be implemented next sprint
-  // try {
-  //     const rawCards = await getAllCards();       // fetch from IndexedDB
-  //     const cards = rawCards.map(Card.fromJSON);  // turn plain objects into Card instances
-  //     const grid = renderCardGrid(cards);
-  //     root.appendChild(grid);
-  //   } catch (err) {
-  //     root.innerHTML = `<p style="color: red;">Error loading cards. Check the console.</p>`;
-  //     console.error('Failed to load cards:', err);
-  //   }
+  const params = new URLSearchParams(window.location.search);
+  const deckId = params.get('deckId');
+  if (!deckId) {
+    console.error("No deckId found in URL.");
+    return;
+  }
+  updateTitleWithDeckName(deckId);
+
+  const deck = await getDeckById(deckId);
+  if (!deck) {
+    console.error(`Deck with id ${deckId} not found.`);
+    return;
+  }
+
+  const cards = await getCardsFromDeck(deckId);
+
+  const grid = renderCardGrid(cards);
+  root.appendChild(grid);
 
   eventListenerSetup();
 }

--- a/src/pages/card-grid/card-grid.js
+++ b/src/pages/card-grid/card-grid.js
@@ -31,7 +31,7 @@ function renderCardGrid(cards) {
     // Edit button
     const editBtn = document.createElement('button');
     editBtn.textContent = 'Edit';
-    editBtn.classList.add('card-btn');
+    editBtn.classList.add('card-btn', 'manage-hidden');
     editBtn.addEventListener('click', (e) => {
       e.stopPropagation(); // prevent triggering cardLink click
       alert(`Edit ${card.name} (not implemented yet)`);
@@ -40,7 +40,7 @@ function renderCardGrid(cards) {
     // Delete button
     const deleteBtn = document.createElement('button');
     deleteBtn.textContent = 'Delete';
-    deleteBtn.classList.add('card-btn');
+    deleteBtn.classList.add('card-btn', 'manage-hidden');
     deleteBtn.addEventListener('click', (e) => {
       e.stopPropagation(); // prevent triggering cardLink click
       alert(`Delete ${card.name} (not implemented yet)`);
@@ -64,8 +64,7 @@ function eventListenerSetup() {
 
   const manage = document.getElementById('manage-toggle');
   manage.addEventListener('click', () => {
-    console.log('Implement toggling of create and delete');
-    console.log('Make it so delete pops up on each card');
+    document.body.classList.toggle('manage-visible');
   });
 
   const create = document.getElementById('create-card');

--- a/src/pages/card-grid/card-grid.js
+++ b/src/pages/card-grid/card-grid.js
@@ -1,4 +1,4 @@
-import { getCardsFromDeck, getDeckById } from "../../data/indexedDB.js";
+import { getCardsFromDeck, getDeckById } from '../../data/indexedDB.js';
 
 async function updateTitleWithDeckName(deckId) {
   const deck = await getDeckById(deckId);
@@ -86,7 +86,7 @@ async function init() {
   const params = new URLSearchParams(window.location.search);
   const deckId = params.get('deckId');
   if (!deckId) {
-    console.error("No deckId found in URL.");
+    console.error('No deckId found in URL.');
     return;
   }
   updateTitleWithDeckName(deckId);

--- a/src/pages/card-grid/style.css
+++ b/src/pages/card-grid/style.css
@@ -39,7 +39,7 @@ h1 {
 }
 
 .manage-visible .manage-hidden {
-  display: inline; 
+  display: inline;
 }
 
 .manage-hidden {

--- a/src/pages/card-grid/style.css
+++ b/src/pages/card-grid/style.css
@@ -37,3 +37,11 @@ h1 {
   height: 100px;
   object-fit: contain;
 }
+
+.manage-visible .manage-hidden {
+  display: inline; 
+}
+
+.manage-hidden {
+  display: none;
+}

--- a/src/test/indexedDB.test.disabled.js
+++ b/src/test/indexedDB.test.disabled.js
@@ -9,23 +9,39 @@ import { Card } from '../data/card.js';
 import { Deck } from '../data/deck.js';
 
 describe('indexedDB data layer – getCardsFromDeck', () => {
-  let deckIdA, deckIdB, deckIdC;   // Electric/Fire, Water, Grass
+  let deckIdA, deckIdB, deckIdC; // Electric/Fire, Water, Grass
 
   beforeAll(async () => {
-    //Create + store four cards 
-    const pikachu    = new Card({ name: 'Pikachu',    imageURL: 'pikachu.png',    type: 'Electric' });
-    const charmander = new Card({ name: 'Charmander', imageURL: 'charmander.png', type: 'Fire'     });
-    const squirtle   = new Card({ name: 'Squirtle',   imageURL: 'squirtle.png',   type: 'Water'    });
-    const bulbasaur  = new Card({ name: 'Bulbasaur',  imageURL: 'bulbasaur.png',  type: 'Grass'    });
+    //Create + store four cards
+    const pikachu = new Card({
+      name: 'Pikachu',
+      imageURL: 'pikachu.png',
+      type: 'Electric',
+    });
+    const charmander = new Card({
+      name: 'Charmander',
+      imageURL: 'charmander.png',
+      type: 'Fire',
+    });
+    const squirtle = new Card({
+      name: 'Squirtle',
+      imageURL: 'squirtle.png',
+      type: 'Water',
+    });
+    const bulbasaur = new Card({
+      name: 'Bulbasaur',
+      imageURL: 'bulbasaur.png',
+      type: 'Grass',
+    });
 
-    const pikachuId    = await addCard(pikachu.toJSON());
+    const pikachuId = await addCard(pikachu.toJSON());
     const charmanderId = await addCard(charmander.toJSON());
-    const squirtleId   = await addCard(squirtle.toJSON());
-    const bulbasaurId  = await addCard(bulbasaur.toJSON());
+    const squirtleId = await addCard(squirtle.toJSON());
+    const bulbasaurId = await addCard(bulbasaur.toJSON());
 
     // Deck A: cardIds pushed directly
     const deckA = new Deck({
-      name:    'Electric/Fire Deck',
+      name: 'Electric/Fire Deck',
       cardIds: [pikachuId, charmanderId],
     });
     deckIdA = await addDeck(deckA.toJSON());
@@ -34,16 +50,15 @@ describe('indexedDB data layer – getCardsFromDeck', () => {
     const deckB = new Deck({ name: 'Water Deck', cardIds: [squirtleId] });
     deckIdB = await addDeck(deckB.toJSON());
 
-    // Deck C: demonstrate Deck.addCard() 
-    const deckC = new Deck({ name: 'Grass Deck' });   // starts empty
-    deckC.addCard(bulbasaurId);                       // use model method (/data/deck.js)
-    deckIdC = await addDeck(deckC.toJSON());          // save updated deck
+    // Deck C: demonstrate Deck.addCard()
+    const deckC = new Deck({ name: 'Grass Deck' }); // starts empty
+    deckC.addCard(bulbasaurId); // use model method (/data/deck.js)
+    deckIdC = await addDeck(deckC.toJSON()); // save updated deck
   });
 
   test('returns only cards from Electric/Fire deck', async () => {
     const cards = await getCardsFromDeck(deckIdA);
-    expect(cards.map(c => c.name).sort())
-      .toEqual(['Charmander', 'Pikachu']);
+    expect(cards.map((c) => c.name).sort()).toEqual(['Charmander', 'Pikachu']);
   });
 
   test('returns only cards from Water deck', async () => {
@@ -59,7 +74,9 @@ describe('indexedDB data layer – getCardsFromDeck', () => {
   });
 
   test('returns empty array for deck with no cards', async () => {
-    const emptyDeckId = await addDeck(new Deck({ name: 'Empty Deck' }).toJSON());
+    const emptyDeckId = await addDeck(
+      new Deck({ name: 'Empty Deck' }).toJSON(),
+    );
     const cards = await getCardsFromDeck(emptyDeckId);
     expect(cards).toEqual([]);
   });

--- a/src/test/indexedDB.test.disabled.js
+++ b/src/test/indexedDB.test.disabled.js
@@ -1,6 +1,13 @@
 /*  ---------------------------------------------------------------
     Unit-test (or integration test?) for getCardsFromDeck(deckId) in data/indexedDB.js.
     - Uses fake-indexeddb so no real browser DB is required.
+
+   * !!!(NOTE):
+   * This test is NOT run in the normal test suite to avoid requiring teammates to install `idb`.
+   * It was verified to work locally. If you want to run it:
+   * 1. Run `npm install idb`
+   * 2. Rename this file to `indexedDB.test.js`
+   * 3. Run `npm run test`
 ---------------------------------------------------------------- */
 
 import 'fake-indexeddb/auto';
@@ -9,39 +16,23 @@ import { Card } from '../data/card.js';
 import { Deck } from '../data/deck.js';
 
 describe('indexedDB data layer – getCardsFromDeck', () => {
-  let deckIdA, deckIdB, deckIdC; // Electric/Fire, Water, Grass
+  let deckIdA, deckIdB, deckIdC;   // Electric/Fire, Water, Grass
 
   beforeAll(async () => {
-    //Create + store four cards
-    const pikachu = new Card({
-      name: 'Pikachu',
-      imageURL: 'pikachu.png',
-      type: 'Electric',
-    });
-    const charmander = new Card({
-      name: 'Charmander',
-      imageURL: 'charmander.png',
-      type: 'Fire',
-    });
-    const squirtle = new Card({
-      name: 'Squirtle',
-      imageURL: 'squirtle.png',
-      type: 'Water',
-    });
-    const bulbasaur = new Card({
-      name: 'Bulbasaur',
-      imageURL: 'bulbasaur.png',
-      type: 'Grass',
-    });
+    //Create + store four cards 
+    const pikachu    = new Card({ name: 'Pikachu',    imageURL: 'pikachu.png',    type: 'Electric' });
+    const charmander = new Card({ name: 'Charmander', imageURL: 'charmander.png', type: 'Fire'     });
+    const squirtle   = new Card({ name: 'Squirtle',   imageURL: 'squirtle.png',   type: 'Water'    });
+    const bulbasaur  = new Card({ name: 'Bulbasaur',  imageURL: 'bulbasaur.png',  type: 'Grass'    });
 
-    const pikachuId = await addCard(pikachu.toJSON());
+    const pikachuId    = await addCard(pikachu.toJSON());
     const charmanderId = await addCard(charmander.toJSON());
-    const squirtleId = await addCard(squirtle.toJSON());
-    const bulbasaurId = await addCard(bulbasaur.toJSON());
+    const squirtleId   = await addCard(squirtle.toJSON());
+    const bulbasaurId  = await addCard(bulbasaur.toJSON());
 
     // Deck A: cardIds pushed directly
     const deckA = new Deck({
-      name: 'Electric/Fire Deck',
+      name:    'Electric/Fire Deck',
       cardIds: [pikachuId, charmanderId],
     });
     deckIdA = await addDeck(deckA.toJSON());
@@ -50,15 +41,16 @@ describe('indexedDB data layer – getCardsFromDeck', () => {
     const deckB = new Deck({ name: 'Water Deck', cardIds: [squirtleId] });
     deckIdB = await addDeck(deckB.toJSON());
 
-    // Deck C: demonstrate Deck.addCard()
-    const deckC = new Deck({ name: 'Grass Deck' }); // starts empty
-    deckC.addCard(bulbasaurId); // use model method (/data/deck.js)
-    deckIdC = await addDeck(deckC.toJSON()); // save updated deck
+    // Deck C: demonstrate Deck.addCard() 
+    const deckC = new Deck({ name: 'Grass Deck' });   // starts empty
+    deckC.addCard(bulbasaurId);                       // use model method (/data/deck.js)
+    deckIdC = await addDeck(deckC.toJSON());          // save updated deck
   });
 
   test('returns only cards from Electric/Fire deck', async () => {
     const cards = await getCardsFromDeck(deckIdA);
-    expect(cards.map((c) => c.name).sort()).toEqual(['Charmander', 'Pikachu']);
+    expect(cards.map(c => c.name).sort())
+      .toEqual(['Charmander', 'Pikachu']);
   });
 
   test('returns only cards from Water deck', async () => {
@@ -74,9 +66,7 @@ describe('indexedDB data layer – getCardsFromDeck', () => {
   });
 
   test('returns empty array for deck with no cards', async () => {
-    const emptyDeckId = await addDeck(
-      new Deck({ name: 'Empty Deck' }).toJSON(),
-    );
+    const emptyDeckId = await addDeck(new Deck({ name: 'Empty Deck' }).toJSON());
     const cards = await getCardsFromDeck(emptyDeckId);
     expect(cards).toEqual([]);
   });

--- a/src/test/indexedDB.test.disabled.js
+++ b/src/test/indexedDB.test.disabled.js
@@ -16,23 +16,39 @@ import { Card } from '../data/card.js';
 import { Deck } from '../data/deck.js';
 
 describe('indexedDB data layer – getCardsFromDeck', () => {
-  let deckIdA, deckIdB, deckIdC;   // Electric/Fire, Water, Grass
+  let deckIdA, deckIdB, deckIdC; // Electric/Fire, Water, Grass
 
   beforeAll(async () => {
-    //Create + store four cards 
-    const pikachu    = new Card({ name: 'Pikachu',    imageURL: 'pikachu.png',    type: 'Electric' });
-    const charmander = new Card({ name: 'Charmander', imageURL: 'charmander.png', type: 'Fire'     });
-    const squirtle   = new Card({ name: 'Squirtle',   imageURL: 'squirtle.png',   type: 'Water'    });
-    const bulbasaur  = new Card({ name: 'Bulbasaur',  imageURL: 'bulbasaur.png',  type: 'Grass'    });
+    //Create + store four cards
+    const pikachu = new Card({
+      name: 'Pikachu',
+      imageURL: 'pikachu.png',
+      type: 'Electric',
+    });
+    const charmander = new Card({
+      name: 'Charmander',
+      imageURL: 'charmander.png',
+      type: 'Fire',
+    });
+    const squirtle = new Card({
+      name: 'Squirtle',
+      imageURL: 'squirtle.png',
+      type: 'Water',
+    });
+    const bulbasaur = new Card({
+      name: 'Bulbasaur',
+      imageURL: 'bulbasaur.png',
+      type: 'Grass',
+    });
 
-    const pikachuId    = await addCard(pikachu.toJSON());
+    const pikachuId = await addCard(pikachu.toJSON());
     const charmanderId = await addCard(charmander.toJSON());
-    const squirtleId   = await addCard(squirtle.toJSON());
-    const bulbasaurId  = await addCard(bulbasaur.toJSON());
+    const squirtleId = await addCard(squirtle.toJSON());
+    const bulbasaurId = await addCard(bulbasaur.toJSON());
 
     // Deck A: cardIds pushed directly
     const deckA = new Deck({
-      name:    'Electric/Fire Deck',
+      name: 'Electric/Fire Deck',
       cardIds: [pikachuId, charmanderId],
     });
     deckIdA = await addDeck(deckA.toJSON());
@@ -41,16 +57,15 @@ describe('indexedDB data layer – getCardsFromDeck', () => {
     const deckB = new Deck({ name: 'Water Deck', cardIds: [squirtleId] });
     deckIdB = await addDeck(deckB.toJSON());
 
-    // Deck C: demonstrate Deck.addCard() 
-    const deckC = new Deck({ name: 'Grass Deck' });   // starts empty
-    deckC.addCard(bulbasaurId);                       // use model method (/data/deck.js)
-    deckIdC = await addDeck(deckC.toJSON());          // save updated deck
+    // Deck C: demonstrate Deck.addCard()
+    const deckC = new Deck({ name: 'Grass Deck' }); // starts empty
+    deckC.addCard(bulbasaurId); // use model method (/data/deck.js)
+    deckIdC = await addDeck(deckC.toJSON()); // save updated deck
   });
 
   test('returns only cards from Electric/Fire deck', async () => {
     const cards = await getCardsFromDeck(deckIdA);
-    expect(cards.map(c => c.name).sort())
-      .toEqual(['Charmander', 'Pikachu']);
+    expect(cards.map((c) => c.name).sort()).toEqual(['Charmander', 'Pikachu']);
   });
 
   test('returns only cards from Water deck', async () => {
@@ -66,7 +81,9 @@ describe('indexedDB data layer – getCardsFromDeck', () => {
   });
 
   test('returns empty array for deck with no cards', async () => {
-    const emptyDeckId = await addDeck(new Deck({ name: 'Empty Deck' }).toJSON());
+    const emptyDeckId = await addDeck(
+      new Deck({ name: 'Empty Deck' }).toJSON(),
+    );
     const cards = await getCardsFromDeck(emptyDeckId);
     expect(cards).toEqual([]);
   });

--- a/src/test/indexedDB.test.js
+++ b/src/test/indexedDB.test.js
@@ -1,0 +1,66 @@
+/*  ---------------------------------------------------------------
+    Unit-test (or integration?) for getCardsFromDeck(deckId) in data/indexedDB.js.
+    - Uses fake-indexeddb so no real browser DB is required.
+---------------------------------------------------------------- */
+
+import 'fake-indexeddb/auto';
+import { addCard, addDeck, getCardsFromDeck } from '../data/indexedDB.js';
+import { Card } from '../data/card.js';
+import { Deck } from '../data/deck.js';
+
+describe('indexedDB data layer – getCardsFromDeck', () => {
+  let deckIdA, deckIdB, deckIdC;   // Electric/Fire, Water, Grass
+
+  beforeAll(async () => {
+    //Create + store four cards 
+    const pikachu    = new Card({ name: 'Pikachu',    imageURL: 'pikachu.png',    type: 'Electric' });
+    const charmander = new Card({ name: 'Charmander', imageURL: 'charmander.png', type: 'Fire'     });
+    const squirtle   = new Card({ name: 'Squirtle',   imageURL: 'squirtle.png',   type: 'Water'    });
+    const bulbasaur  = new Card({ name: 'Bulbasaur',  imageURL: 'bulbasaur.png',  type: 'Grass'    });
+
+    const pikachuId    = await addCard(pikachu.toJSON());
+    const charmanderId = await addCard(charmander.toJSON());
+    const squirtleId   = await addCard(squirtle.toJSON());
+    const bulbasaurId  = await addCard(bulbasaur.toJSON());
+
+    // Deck A: cardIds pushed directly
+    const deckA = new Deck({
+      name:    'Electric/Fire Deck',
+      cardIds: [pikachuId, charmanderId],
+    });
+    deckIdA = await addDeck(deckA.toJSON());
+
+    // Deck B
+    const deckB = new Deck({ name: 'Water Deck', cardIds: [squirtleId] });
+    deckIdB = await addDeck(deckB.toJSON());
+
+    // Deck C: demonstrate Deck.addCard() 
+    const deckC = new Deck({ name: 'Grass Deck' });   // starts empty
+    deckC.addCard(bulbasaurId);                       // use model method (/data/deck.js)
+    deckIdC = await addDeck(deckC.toJSON());          // save updated deck
+  });
+
+  test('returns only cards from Electric/Fire deck', async () => {
+    const cards = await getCardsFromDeck(deckIdA);
+    expect(cards.map(c => c.name).sort())
+      .toEqual(['Charmander', 'Pikachu']);
+  });
+
+  test('returns only cards from Water deck', async () => {
+    const cards = await getCardsFromDeck(deckIdB);
+    expect(cards.length).toBe(1);
+    expect(cards[0].name).toBe('Squirtle');
+  });
+
+  test('returns cards added via Deck.addCard()', async () => {
+    const cards = await getCardsFromDeck(deckIdC);
+    expect(cards.length).toBe(1);
+    expect(cards[0].name).toBe('Bulbasaur');
+  });
+
+  test('returns empty array for deck with no cards', async () => {
+    const emptyDeckId = await addDeck(new Deck({ name: 'Empty Deck' }).toJSON());
+    const cards = await getCardsFromDeck(emptyDeckId);
+    expect(cards).toEqual([]);
+  });
+});

--- a/src/test/indexedDB.test.js
+++ b/src/test/indexedDB.test.js
@@ -1,5 +1,5 @@
 /*  ---------------------------------------------------------------
-    Unit-test (or integration?) for getCardsFromDeck(deckId) in data/indexedDB.js.
+    Unit-test (or integration test?) for getCardsFromDeck(deckId) in data/indexedDB.js.
     - Uses fake-indexeddb so no real browser DB is required.
 ---------------------------------------------------------------- */
 


### PR DESCRIPTION
## Describe your changes

The card grid now loads and displays only the cards associated with the selected deck. Additionally, I implemented delete functionality for individual cards.

- Parses the deckId from the query string (card-grid.html?deckId=...)

- Loads and displays only the cards listed in that deck’s cardIds array

- Clicking a card still navigates to its individual view

- A Manage button toggles visibility of create/delete buttons

- Clicking an individual card’s Delete button:

   - Deletes the card from IndexedDB

   - Removes the card's ID from the deck’s cardIds array

   - Saves the updated deck

   - Refreshes the page to reflect changes (This needs tweaking later)

- Also, I disabled the jest test for indexedDB after thoroughly testing because it requires npm install idb, which does not work for the rest of the app. 

## Issue ticket number and link (connect the issue you aim to close with this pull request
Closes #62 
