### PR TITLE
Card grid integration

### DIFF
--- a/src/pages/card-grid/card-grid.html
+++ b/src/pages/card-grid/card-grid.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
-    <h1>All Pokémon Cards</h1>
+    <h1>No Deck Chosen</h1>
 
     <div class="sort-controls">
       <label for="sort-cards" class="sort-label">Sort By:</label>

--- a/src/pages/card-grid/card-grid.html
+++ b/src/pages/card-grid/card-grid.html
@@ -31,7 +31,7 @@
     </div>
     <div class="manage-controls">
       <button id="manage-toggle">Manage</button>
-      <button id="create-card" class="manage-hidden">Create</button>
+      <button id="create-card">Create</button>
     </div>
   </body>
 </html>

--- a/src/pages/card-grid/card-grid.js
+++ b/src/pages/card-grid/card-grid.js
@@ -148,11 +148,13 @@ function renderCardGrid(cards) {
 }
 
 //sets up the search, filter and manage buttons
-function backSearchSortManageBtnsSetup(allCards) {
+function backSearchSortManageBtnsSetup(allCards = []) {
   const back = document.getElementById('go-back');
   back.addEventListener('click', () => {
     window.location.href = '../deck-grid/deckviewui.html';
   });
+
+  if (!allCards.length) return;
 
   //Manage Button
   const manage = document.getElementById('manage-toggle');
@@ -331,3 +333,5 @@ async function init() {
 }
 
 init();
+
+backSearchSortManageBtnsSetup();

--- a/src/pages/card-grid/card-grid.js
+++ b/src/pages/card-grid/card-grid.js
@@ -72,7 +72,7 @@ async function updateTitleWithDeckName(deckId) {
   const deck = await getDeckById(deckId);
   const heading = document.querySelector('h1');
   if (deck && deck.name) {
-    heading.textContent = `${deck.name} Deck`;
+    heading.textContent = `${deck.name}`;
   }
 }
 
@@ -151,9 +151,7 @@ function renderCardGrid(cards) {
 function backSearchSortManageBtnsSetup(allCards) {
   const back = document.getElementById('go-back');
   back.addEventListener('click', () => {
-    //TODO Implement go back once Max finishes his all-deck-view implementations
-    //window.location.href = `../all-deck-view
-    console.log('Implement Go Back');
+    window.location.href = '../deck-grid/deckviewui.html';
   });
 
   //Manage Button
@@ -163,10 +161,11 @@ function backSearchSortManageBtnsSetup(allCards) {
   });
 
   //Create Button
-  //TODO Implement Create Button
   const create = document.getElementById('create-card');
   create.addEventListener('click', () => {
-    console.log('Implement creation of cards');
+    const params = new URLSearchParams(window.location.search);
+    const deckId = params.get('deckId');
+    window.location.href = `../create-card/create-card.html?deckId=${deckId}`;
   });
 
   //Sort Cards Selection

--- a/src/pages/create-card/create-card.html
+++ b/src/pages/create-card/create-card.html
@@ -23,7 +23,7 @@
       <input type="text" id="card-name" required />
 
       <label for="card-type">Type</label>
-      <input type="text" id="card-type" required />
+      <input type="text" id="card-type" />
 
       <label for="card-hp">HP</label>
       <input type="number" id="card-hp" />
@@ -35,6 +35,8 @@
 
       <button type="button" id="back-button">Back</button>
     </form>
+    
+    <div id="feedback-message" class="feedback-message"></div>
 
     <script type="module" src="./create-card.js"></script>
   </body>

--- a/src/pages/create-card/create-card.html
+++ b/src/pages/create-card/create-card.html
@@ -32,6 +32,8 @@
       <input type="text" id="card-evolution" />
 
       <button type="submit">Save Card</button>
+
+      <button type="button" id="back-button">Back</button>
     </form>
 
     <script type="module" src="./create-card.js"></script>

--- a/src/pages/create-card/create-card.html
+++ b/src/pages/create-card/create-card.html
@@ -35,7 +35,7 @@
 
       <button type="button" id="back-button">Back</button>
     </form>
-    
+
     <div id="feedback-message" class="feedback-message"></div>
 
     <script type="module" src="./create-card.js"></script>

--- a/src/pages/create-card/create-card.js
+++ b/src/pages/create-card/create-card.js
@@ -25,7 +25,7 @@ function toBase64(file) {
 function showFeedbackMessage(message, isError = false) {
   const messageEl = document.getElementById('feedback-message');
   messageEl.textContent = message;
-  messageEl.className = 'feedback-message'; 
+  messageEl.className = 'feedback-message';
   messageEl.classList.add(isError ? 'feedback-error' : 'feedback-success');
   messageEl.style.display = 'block';
 
@@ -44,7 +44,7 @@ imageUpload.addEventListener('change', async (e) => {
   }
 });
 
-backButton.addEventListener('click', () =>  {
+backButton.addEventListener('click', () => {
   window.location.href = `../card-grid/card-grid.html?deckId=${deckId}`;
 });
 
@@ -53,7 +53,10 @@ form.addEventListener('submit', async (e) => {
   e.preventDefault(); // prevents losing info from page reload
 
   if (!deckId) {
-    showFeedbackMessage('You currently have no deck selected, access your decks from the deck view.', true);
+    showFeedbackMessage(
+      'You currently have no deck selected, access your decks from the deck view.',
+      true,
+    );
     return;
   }
 

--- a/src/pages/create-card/create-card.js
+++ b/src/pages/create-card/create-card.js
@@ -4,6 +4,7 @@ import { addCard, getDeckById, updateDeck } from '../../data/indexedDB.js';
 const form = document.getElementById('card-form');
 const imageUpload = document.getElementById('image-upload');
 const imagePreview = document.getElementById('image-preview');
+const backButton = document.getElementById('back-button');
 let imageURL = '';
 
 //Grab deckId from the URL
@@ -28,6 +29,10 @@ imageUpload.addEventListener('change', async (e) => {
     imagePreview.src = imageURL;
     imagePreview.style.display = 'block';
   }
+});
+
+backButton.addEventListener('click', () =>  {
+  window.location.href = `../card-grid/card-grid.html?deckId=${deckId}`;
 });
 
 // When the form is submitted, create a new card and store it in IndexedDB

--- a/src/pages/create-card/create-card.js
+++ b/src/pages/create-card/create-card.js
@@ -21,6 +21,19 @@ function toBase64(file) {
   });
 }
 
+//Function for user feedback
+function showFeedbackMessage(message, isError = false) {
+  const messageEl = document.getElementById('feedback-message');
+  messageEl.textContent = message;
+  messageEl.className = 'feedback-message'; 
+  messageEl.classList.add(isError ? 'feedback-error' : 'feedback-success');
+  messageEl.style.display = 'block';
+
+  setTimeout(() => {
+    messageEl.style.display = 'none';
+  }, 5000);
+}
+
 //When an image is uploaded... change the image preview to that image
 imageUpload.addEventListener('change', async (e) => {
   const file = e.target.files[0];
@@ -38,6 +51,17 @@ backButton.addEventListener('click', () =>  {
 // When the form is submitted, create a new card and store it in IndexedDB
 form.addEventListener('submit', async (e) => {
   e.preventDefault(); // prevents losing info from page reload
+
+  if (!deckId) {
+    showFeedbackMessage('You currently have no deck selected, access your decks from the deck view.', true);
+    return;
+  }
+
+  const deck = await getDeckById(deckId);
+  if (!deck) {
+    showFeedbackMessage('Deck not found. Please use valid deck link.', true);
+    return;
+  }
 
   const name = document.getElementById('card-name').value;
   const type = document.getElementById('card-type').value;
@@ -58,12 +82,13 @@ form.addEventListener('submit', async (e) => {
       }
     }
 
-    alert('Card just saved succesfully.');
+    console.log('Card saved successfully');
+    showFeedbackMessage('Card saved successfully!');
     form.reset();
     imagePreview.style.display = 'none';
     imageURL = '';
   } catch (error) {
     console.error('Failed to save card!! ->', error);
-    alert('Error saving the card, check console');
+    showFeedbackMessage('Failed to save card, check console.', true);
   }
 });

--- a/src/pages/create-card/style.css
+++ b/src/pages/create-card/style.css
@@ -44,7 +44,6 @@ img#image-preview {
   display: block;
 }
 
-
 .feedback-message {
   margin-top: 1rem;
   padding: 0.5rem;

--- a/src/pages/create-card/style.css
+++ b/src/pages/create-card/style.css
@@ -43,3 +43,24 @@ img#image-preview {
   height: auto;
   display: block;
 }
+
+
+.feedback-message {
+  margin-top: 1rem;
+  padding: 0.5rem;
+  font-weight: bold;
+  border-radius: 5px;
+  display: none;
+}
+
+.feedback-success {
+  color: green;
+  background-color: #e6ffe6;
+  border: 1px solid green;
+}
+
+.feedback-error {
+  color: red;
+  background-color: #ffe6e6;
+  border: 1px solid red;
+}


### PR DESCRIPTION
## Describe your changes
1. Integrated card-grid buttons (back to Deck View, Create Card) 
2. I have integrated create card so that it is deck aware, you create a single card whichever deck you were on in card-grid
3. Added working back button to create-card
4. Changed "Create" button on card-grid so that it is always visible, made more sense.
5. Added useful user error messages to create-card
6. If link does not have a deckId parameter, or the deckId does not point to a valid deck:
   - create-card throws an error to the user and in the console, advises to go back to deck view. Does NOT allow creation of a card without deck specified anymore
   - card-grid now allows you to go back to deck view aswel (did not work before) and displays "No Deck Chosen"



## Issue ticket number and link (connect the issue you aim to close with this pull request
Closes #80 
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
