### PR TITLE
Made sure create button works even when deck is empty

### DIFF
--- a/src/pages/card-grid/card-grid.js
+++ b/src/pages/card-grid/card-grid.js
@@ -154,20 +154,20 @@ function backSearchSortManageBtnsSetup(allCards = []) {
     window.location.href = '../deck-grid/deckviewui.html';
   });
 
-  if (!allCards.length) return;
-
-  //Manage Button
-  const manage = document.getElementById('manage-toggle');
-  manage.addEventListener('click', () => {
-    document.body.classList.toggle('manage-visible');
-  });
-
   //Create Button
   const create = document.getElementById('create-card');
   create.addEventListener('click', () => {
     const params = new URLSearchParams(window.location.search);
     const deckId = params.get('deckId');
     window.location.href = `../create-card/create-card.html?deckId=${deckId}`;
+  });
+
+  if (!allCards.length) return;
+
+  //Manage Button
+  const manage = document.getElementById('manage-toggle');
+  manage.addEventListener('click', () => {
+    document.body.classList.toggle('manage-visible');
   });
 
   //Sort Cards Selection


### PR DESCRIPTION
## Describe your changes
The bug was that setting up create card happened after the early exit in setting up buttons. Back button was the only working button with an empty deck. Now both "back" and "create" work with empty decks.

## Issue ticket number and link (connect the issue you aim to close with this pull request
Closes #87 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
